### PR TITLE
feat: add filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"@commitlint/cli": "^19.7.1",
 		"@commitlint/config-conventional": "^19.7.1",
 		"@eslint/js": "^9.21.0",
+		"@types/qs": "^6.14.0",
 		"cpy-cli": "^5.0.0",
 		"drizzle-kit": "1.0.0-beta.1-c0277c0",
 		"eslint": "^9.21.0",
@@ -77,6 +78,7 @@
 		"ioredis": "^5.6.1",
 		"node-object-hash": "^3.1.1",
 		"postgres": "^3.4.5",
+		"qs": "^6.14.0",
 		"toad-scheduler": "^3.1.0",
 		"zod": "^3.24.2"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       postgres:
         specifier: ^3.4.5
         version: 3.4.7
+      qs:
+        specifier: ^6.14.0
+        version: 6.14.0
       toad-scheduler:
         specifier: ^3.1.0
         version: 3.1.0
@@ -75,6 +78,9 @@ importers:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.28.0
+      '@types/qs':
+        specifier: ^6.14.0
+        version: 6.14.0
       cpy-cli:
         specifier: ^5.0.0
         version: 5.0.0
@@ -647,6 +653,9 @@ packages:
   '@types/node@22.15.29':
     resolution: {integrity: sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
   '@typescript-eslint/eslint-plugin@8.33.1':
     resolution: {integrity: sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -815,6 +824,14 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1062,6 +1079,10 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
@@ -1081,6 +1102,18 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -1270,6 +1303,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1277,6 +1313,14 @@ packages:
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -1317,6 +1361,10 @@ packages:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1326,6 +1374,14 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   helmet@8.1.0:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
@@ -1547,6 +1603,10 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -1604,6 +1664,10 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -1750,6 +1814,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -1839,6 +1907,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2487,6 +2571,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qs@6.14.0': {}
+
   '@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -2674,6 +2760,16 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   callsites@3.1.0: {}
 
   camel-case@4.1.2:
@@ -2828,6 +2924,12 @@ snapshots:
     optionalDependencies:
       postgres: 3.4.7
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   emoji-regex@10.4.0: {}
 
   emoji-regex@8.0.0: {}
@@ -2843,6 +2945,14 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild-register@3.6.0(esbuild@0.25.5):
     dependencies:
@@ -3121,9 +3231,29 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@8.0.1: {}
 
@@ -3163,11 +3293,19 @@ snapshots:
       merge2: 1.4.1
       slash: 4.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   helmet@8.1.0: {}
 
@@ -3363,6 +3501,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  math-intrinsics@1.1.0: {}
+
   meow@12.1.1: {}
 
   merge-stream@2.0.0: {}
@@ -3406,6 +3546,8 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  object-inspect@1.13.4: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -3553,6 +3695,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
@@ -3616,6 +3762,34 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@4.1.0: {}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,12 +20,14 @@ import { AsyncTask, CronJob } from 'toad-scheduler'
 import { SCHEDULE_TYPE } from './core/constants/parsers.js'
 import { delay, isDbEmpty } from './core/utils/index.js'
 import fastifySchedule from '@fastify/schedule'
+import qs from 'qs'
 
 export class App {
 	private readonly app: AppInstance
 
 	constructor() {
 		this.app = fastify({
+			querystringParser: qs.parse,
 			logger: {
 				transport: {
 					target: 'pino-pretty',

--- a/src/modules/auditoriums/handlers/index.ts
+++ b/src/modules/auditoriums/handlers/index.ts
@@ -1,6 +1,7 @@
-import type {
-	GET_SCHEDULE_PARAMS,
-	GET_SCHEDULE_QUERY,
+import {
+	GET_SCHEDULE_QUERY_SCHEMA,
+	type GET_SCHEDULE_PARAMS,
+	type GET_SCHEDULE_QUERY,
 } from '@/modules/schedule/schemas/index.js'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 
@@ -25,7 +26,9 @@ export const getAuditoriumSchedule = async (
 	const { auditoriumsService } = request.diScope.cradle
 	const { id } = request.params
 
-	const data = await auditoriumsService.getSchedule({ id, ...request.query })
+	const query = GET_SCHEDULE_QUERY_SCHEMA.safeParse(request.query)
+
+	const data = await auditoriumsService.getSchedule({ id, ...query.data! })
 
 	return reply.status(200).send(data)
 }

--- a/src/modules/auditoriums/repositories/AuditoriumsRepository.ts
+++ b/src/modules/auditoriums/repositories/AuditoriumsRepository.ts
@@ -10,6 +10,7 @@ import type { GET_SCHEDULE_OPTIONS } from '@/modules/schedule/schemas/index.js'
 
 import {
 	buildScheduleQuery,
+	getFiltersQuery,
 	getTimeIntervalQuery,
 } from '@/modules/schedule/utils/index.js'
 
@@ -35,6 +36,10 @@ export class AuditoriumsRepositoryImpl implements AuditoriumsRepository {
 		const timeInterval = getTimeIntervalQuery(options)
 
 		whereClause.push(...timeInterval)
+
+		const filters = getFiltersQuery(options.filters)
+
+		whereClause.push(...filters)
 
 		const query = buildScheduleQuery(whereClause)
 

--- a/src/modules/groups/handlers/index.ts
+++ b/src/modules/groups/handlers/index.ts
@@ -1,7 +1,8 @@
 import type { GET_ENTITY_BY_ID } from '@/core/schemas/index.js'
-import type {
-	GET_SCHEDULE_PARAMS,
-	GET_SCHEDULE_QUERY,
+import {
+	GET_SCHEDULE_QUERY_SCHEMA,
+	type GET_SCHEDULE_PARAMS,
+	type GET_SCHEDULE_QUERY,
 } from '@/modules/schedule/schemas/index.js'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 
@@ -26,7 +27,9 @@ export const getGroupSchedule = async (
 	const { groupsService } = request.diScope.cradle
 	const { id } = request.params
 
-	const data = await groupsService.getSchedule({ id, ...request.query })
+	const query = GET_SCHEDULE_QUERY_SCHEMA.safeParse(request.query)
+
+	const data = await groupsService.getSchedule({ id, ...query.data! })
 
 	return reply.status(200).send(data)
 }

--- a/src/modules/groups/repositories/GroupsRepository.ts
+++ b/src/modules/groups/repositories/GroupsRepository.ts
@@ -9,6 +9,7 @@ import type { Group, Schedule, Subject, Teacher } from '@/db/types.js'
 import type { GET_SCHEDULE_OPTIONS } from '@/modules/schedule/schemas/index.js'
 import {
 	buildScheduleQuery,
+	getFiltersQuery,
 	getTimeIntervalQuery,
 } from '@/modules/schedule/utils/index.js'
 import { SQL, asc, eq, sql } from 'drizzle-orm'
@@ -80,6 +81,10 @@ export class GroupsRepositoryImpl implements GroupsRepository {
 		const timeInterval = getTimeIntervalQuery(options)
 
 		whereClause.push(...timeInterval)
+
+		const filters = getFiltersQuery(options.filters)
+
+		whereClause.push(...filters)
 
 		const query = buildScheduleQuery(whereClause)
 

--- a/src/modules/groups/routes/index.ts
+++ b/src/modules/groups/routes/index.ts
@@ -1,19 +1,18 @@
+import { GET_ENTITY_BY_ID_SCHEMA } from '@/core/schemas/index.js'
 import type { Routes } from '@/core/types/routes.js'
+import { generateResponseSchema } from '@/core/utils/schemas.js'
+import {
+	GET_SCHEDULE_PARAMS_SCHEMA,
+	SCHEDULE_SCHEMA,
+} from '@/modules/schedule/schemas/index.js'
+import { TEACHER_SCHEMA } from '@/modules/teachers/schemas/index.js'
 import {
 	getGroupSchedule,
 	getGroupSubjects,
 	getGroupTeachers,
 	getGroups,
 } from '../handlers/index.js'
-import { generateResponseSchema } from '@/core/utils/schemas.js'
 import { GROUP_SCHEMA, SUBJECT_SCHEMA } from '../schemas/index.js'
-import {
-	GET_SCHEDULE_PARAMS_SCHEMA,
-	GET_SCHEDULE_QUERY_SCHEMA,
-	SCHEDULE_SCHEMA,
-} from '@/modules/schedule/schemas/index.js'
-import { GET_ENTITY_BY_ID_SCHEMA } from '@/core/schemas/index.js'
-import { TEACHER_SCHEMA } from '@/modules/teachers/schemas/index.js'
 
 export const getGroupsRoutes = (): Routes => ({
 	routes: [
@@ -41,7 +40,6 @@ export const getGroupsRoutes = (): Routes => ({
 				description: 'Get schedule for a group in particular time interval',
 				tags: ['Groups'],
 				params: GET_SCHEDULE_PARAMS_SCHEMA,
-				querystring: GET_SCHEDULE_QUERY_SCHEMA,
 				response: {
 					200: generateResponseSchema(SCHEDULE_SCHEMA.array()).describe(
 						'Successful response',

--- a/src/modules/schedule/schemas/index.ts
+++ b/src/modules/schedule/schemas/index.ts
@@ -2,6 +2,10 @@ import { eventTypeEnum } from '@/db/schema/event-type-enum.js'
 import { GROUP_SCHEMA } from '@/modules/groups/schemas/index.js'
 import { TEACHER_SCHEMA } from '@/modules/teachers/schemas/index.js'
 import { z } from 'zod'
+import {
+	transformEventTypesParam,
+	transformIdsParam,
+} from '../utils/query-string.js'
 
 const SCHEDULE_SCHEMA = z.object({
 	id: z.number().int().describe('Identifier of double period'),
@@ -40,7 +44,19 @@ const GET_SCHEDULE_PARAMS_SCHEMA = z.object({
 
 type GET_SCHEDULE_PARAMS = z.infer<typeof GET_SCHEDULE_PARAMS_SCHEMA>
 
-const GET_SCHEDULE_QUERY_SCHEMA = z.object({
+const GET_SCHEDULE_FILTERS_SCHEMA = z.object({
+	lessonTypes: z
+		.string()
+		.nullable()
+		.default(null)
+		.transform(transformEventTypesParam),
+	teachers: z.string().nullable().default(null).transform(transformIdsParam),
+	auditoriums: z.string().nullable().default(null).transform(transformIdsParam),
+})
+
+type GET_SCHEDULE_FILTERS = z.infer<typeof GET_SCHEDULE_FILTERS_SCHEMA>
+
+const GET_SCHEDULE_TIME_INTERVAL_SCHEMA = z.object({
 	startedAt: z.coerce
 		.number()
 		.min(0)
@@ -61,13 +77,33 @@ const GET_SCHEDULE_QUERY_SCHEMA = z.object({
 		.describe('End time of the schedule range'),
 })
 
+type GET_SCHEDULE_TIME_INTERVAL = z.infer<
+	typeof GET_SCHEDULE_TIME_INTERVAL_SCHEMA
+>
+
+const GET_SCHEDULE_QUERY_SCHEMA = GET_SCHEDULE_TIME_INTERVAL_SCHEMA.extend({
+	filters: GET_SCHEDULE_FILTERS_SCHEMA.default({
+		auditoriums: null,
+		lessonTypes: null,
+		teachers: null,
+	}),
+})
+
 type GET_SCHEDULE_QUERY = z.infer<typeof GET_SCHEDULE_QUERY_SCHEMA>
 
 type GET_SCHEDULE_OPTIONS = GET_SCHEDULE_PARAMS & GET_SCHEDULE_QUERY
 
 export {
+	GET_SCHEDULE_FILTERS_SCHEMA,
 	GET_SCHEDULE_PARAMS_SCHEMA,
 	GET_SCHEDULE_QUERY_SCHEMA,
+	GET_SCHEDULE_TIME_INTERVAL_SCHEMA,
 	SCHEDULE_SCHEMA,
 }
-export type { GET_SCHEDULE_PARAMS, GET_SCHEDULE_QUERY, GET_SCHEDULE_OPTIONS }
+export type {
+	GET_SCHEDULE_FILTERS,
+	GET_SCHEDULE_OPTIONS,
+	GET_SCHEDULE_PARAMS,
+	GET_SCHEDULE_QUERY,
+	GET_SCHEDULE_TIME_INTERVAL,
+}

--- a/src/modules/schedule/utils/query-string.ts
+++ b/src/modules/schedule/utils/query-string.ts
@@ -1,0 +1,17 @@
+import type { Maybe } from '@/core/types/index.js'
+import { eventTypeEnum } from '@/db/schema/event-type-enum.js'
+
+export const queryParamToArray = (s: Maybe<string>): string[] => {
+	return !s ? [] : s.includes(',') ? s.split(',') : [s]
+}
+
+export const transformEventTypesParam = (s: Maybe<string>): string[] => {
+	return queryParamToArray(s).filter((item) => {
+		// @ts-expect-error will be fixed soon
+		return eventTypeEnum.enumValues.includes(item)
+	})
+}
+
+export const transformIdsParam = (s: Maybe<string>): number[] => {
+	return queryParamToArray(s).map(Number).filter(Number.isInteger)
+}

--- a/src/modules/teachers/handlers/index.ts
+++ b/src/modules/teachers/handlers/index.ts
@@ -1,6 +1,7 @@
-import type {
-	GET_SCHEDULE_PARAMS,
-	GET_SCHEDULE_QUERY,
+import {
+	GET_SCHEDULE_QUERY_SCHEMA,
+	type GET_SCHEDULE_PARAMS,
+	type GET_SCHEDULE_QUERY,
 } from '@/modules/schedule/schemas/index.js'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 
@@ -25,7 +26,9 @@ export const getTeacherSchedule = async (
 	const { teachersService } = request.diScope.cradle
 	const { id } = request.params
 
-	const data = await teachersService.getSchedule({ id, ...request.query })
+	const query = GET_SCHEDULE_QUERY_SCHEMA.safeParse(request.query)
+
+	const data = await teachersService.getSchedule({ id, ...query.data! })
 
 	return reply.status(200).send(data)
 }

--- a/src/modules/teachers/repositories/TeachersRepository.ts
+++ b/src/modules/teachers/repositories/TeachersRepository.ts
@@ -9,6 +9,7 @@ import { SQL, asc, sql } from 'drizzle-orm'
 import type { GET_SCHEDULE_OPTIONS } from '@/modules/schedule/schemas/index.js'
 import {
 	buildScheduleQuery,
+	getFiltersQuery,
 	getTimeIntervalQuery,
 } from '@/modules/schedule/utils/index.js'
 
@@ -34,6 +35,10 @@ export class TeachersRepositoryImpl implements TeachersRepository {
 		const timeInterval = getTimeIntervalQuery(options)
 
 		whereClause.push(...timeInterval)
+
+		const filters = getFiltersQuery(options.filters)
+
+		whereClause.push(...filters)
 
 		const query = buildScheduleQuery(whereClause)
 


### PR DESCRIPTION
## Description

This PR introduces filters for schedule, it now can be filtered by 4 entities:
- lesson types;
- teachers;
- auditoriums; 
- subjects.

## Example

It will return all lessons, excluding lectures:

```
/api/groups/11103296/schedule?filters[lessonTypes]=Лк
```
